### PR TITLE
Fixes "Undefined variable: joinDeclaration" in `getSqlTableAliasForJoin()`

### DIFF
--- a/SqlIndexWalker.php
+++ b/SqlIndexWalker.php
@@ -126,7 +126,7 @@ class SqlIndexWalker extends SqlWalker
     protected function getSqlTableAliasForJoin(AST\Join $join, $dqlAlias): string
     {
         if ($join->joinAssociationDeclaration instanceof AST\RangeVariableDeclaration) {
-            $class = $this->em->getClassMetadata($joinDeclaration->abstractSchemaName);
+            $class = $this->em->getClassMetadata($join->joinAssociationDeclaration->abstractSchemaName);
 
             return $this->getSQLTableAlias($class->table['name'], $dqlAlias);
         } elseif ($join->joinAssociationDeclaration instanceof AST\JoinAssociationDeclaration) {


### PR DESCRIPTION
Hi @ggergo 

I was trying to develop a similar Walker, but I was struggling with mapping DQL table aliases with final SQL table aliases. It seemed like an impossible task since I am not super familiar with the ORM internals. Then I found your bundle and I am amazed on how well developed it is, it does everything that is needed.

While trying to integrate it, I was having an undefined variable crash, so I looked at the code and I obviously found it. I am not sure what that undefined variable is doing there, and what the story behind it is, but I am letting you know though this attempt to fix it via PR. 

Feel free to give some further instructions on how you think the final working code should look like, since you have all the context of the project. At first impression, with this fix, the code works as expected!

Thanks a lot!