### PR TITLE
Allow doctrine/orm 3.0 without forcing a newer version of PHP.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/orm": "^2.6"
+        "doctrine/orm": "^2.6 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^7 || ^9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
While doctrine/orm 3.0 requires PHP 8.1, this commit does not force requiring it. This commit simply allows for those projects that are already using PHP 8.1 to upgrade to doctrine/orm 3.0 if they want it.

The commit also allows PHPUnit 9 as a development dependency. To test this package with doctrine/orm 3.0, we have to test it with PHP 8.1 and PHPUnit 7 requires PHP ^7.1.

PHPUnit 8 is skipped because it seems to have an issue with creating mocks of the SqlWalker. In particular, the type for the $condExpr parameter of the walkJoinAssociationDeclaration method is 'AST\ConditionalExpression|AST\Phase2OptimizableConditional|null'. When the mock is built, the code that defines that parameter is written as '?$condExpr = NULL', which is invalid PHP. This causes an exception to be thrown when eval'ing the mock.